### PR TITLE
Add Agent QA to AI for Testing

### DIFF
--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -60,6 +60,7 @@ AI tools are now essential in modern software development. They help you write c
 | [CodiumAI (Qodo)](https://www.qodo.ai/) | Generates unit tests for your .NET methods automatically |
 | [Diffblue Cover](https://www.diffblue.com/) | Enterprise tool that writes xUnit/NUnit tests for Java and .NET code |
 | [Copilot for unit tests](https://github.com/features/copilot) | Use GitHub Copilot chat with `/tests` command to generate test cases |
+| [Agent QA](https://github.com/vostride/agent-qa) | Source-available agent for natural-language web and mobile end-to-end tests with persistent test memory |
 
 ## AI for Architecture & Diagrams
 

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -60,7 +60,7 @@ AI tools are now essential in modern software development. They help you write c
 | [CodiumAI (Qodo)](https://www.qodo.ai/) | Generates unit tests for your .NET methods automatically |
 | [Diffblue Cover](https://www.diffblue.com/) | Enterprise tool that writes xUnit/NUnit tests for Java and .NET code |
 | [Copilot for unit tests](https://github.com/features/copilot) | Use GitHub Copilot chat with `/tests` command to generate test cases |
-| [Agent QA](https://github.com/vostride/agent-qa) | Source-available agent for natural-language web and mobile end-to-end tests with persistent test memory |
+| [Agent QA](https://github.com/vostride/agent-qa) | Language-independent external harness for natural-language web/mobile tests against deployed ASP.NET or .NET-backed apps, with persistent test memory; not a .NET package. FSL-1.1-ALv2, converting to Apache-2.0 after two years |
 
 ## AI for Architecture & Diagrams
 


### PR DESCRIPTION
## What does this PR add?

Add Agent QA under **AI for Testing** as a language-independent end-to-end testing companion for .NET teams.

Agent QA runs natural-language web and mobile user flows and retains scoped test memory and evidence across runs. It can test deployed ASP.NET or .NET-backed applications from the outside; this PR does not claim that Agent QA is a .NET package or framework integration.

The entry says `source-available` because Agent QA currently uses FSL-1.1-ALv2, which converts to Apache-2.0 after two years.

## Checklist

- [x] The resource is relevant to .NET / C# developers.
- [x] I added it to the correct file under `docs/`.
- [x] The link works and is not a duplicate.
- [x] I followed the existing format and added a short, neutral description.
- [x] I disclosed my affiliation below; there is no affiliate link.

## Affiliation disclosure

I am affiliated with the Agent QA project. The repository link is direct and contains no affiliate or referral parameters.

## Validation

- `git diff --check`
- direct repository URL verified
- standard awesome-lint reaches only repository-root metadata findings and reports no finding on `docs/ai-tools.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agent QA to the list of AI testing tools.
  * Included a link to its repository and a brief overview of its language-independent web and mobile end-to-end testing capabilities, persistent test memory, and licensing terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->